### PR TITLE
마이페이지 레이아웃 및 디자인 수정

### DIFF
--- a/src/app/mypage/qna/page.tsx
+++ b/src/app/mypage/qna/page.tsx
@@ -1,3 +1,31 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
 export default function QnaPage() {
-  return <div>페이지 준비중입니다.</div>;
+  const router = useRouter();
+  return (
+    <div className="flex flex-col items-center justify-between h-screen text-center pt-[21.75rem] pb-24">
+      <div className="flex flex-col gap-12">
+        <Image
+          src="/images/img-error.png"
+          alt="img-error"
+          width={180}
+          height={180}
+          className="w-[11.25rem] h-[11.25rem] m-auto"
+        />
+        <div className="flex flex-col gap-[3.75rem]">
+          <h3 className="text-7xl text-black-700 font-semibold">페이지 준비중입니다.</h3>
+          <p className="text-[2rem] text-black-400">
+            현재 페이지 제작을 준비하고 있으니 조금만 기다려주세요. <br /> 감사합니다.
+          </p>
+        </div>
+      </div>
+      <Button onClick={() => router.push("/main")} variant="primary">
+        홈으로 돌아가기
+      </Button>
+    </div>
+  );
 }

--- a/src/shared/ui/LetterCard.tsx
+++ b/src/shared/ui/LetterCard.tsx
@@ -12,7 +12,7 @@ export const LetterCard = ({ letter, handleModalOpen }: LetterCardProps) => {
     <div className="flex flex-col pt-9 pl-9 pr-9 pb-[3.75rem] shadow-card bg-white text-xl">
       <div className="relative w-full h-[27.75rem] p-5 rounded-[0.625rem]">
         {letter.isRead === false && letter.letterId && (
-          <div className="absolute top-5 left-5 pt-4 pb-4 pl-6 pr-6 bg-primary rounded-full font-gangwonEduAll font-bold text-white text-[2rem]">
+          <div className="absolute z-50 top-5 left-5 pt-4 pb-4 pl-6 pr-6 bg-primary rounded-full font-gangwonEduAll font-bold text-white text-[2rem]">
             New
           </div>
         )}


### PR DESCRIPTION
### 작업 내용
cc. @CRITICBANGGU 

1. 마이페이지 레이아웃 및 수정
- 기존에 `((default))` 경로에 있었는데, 디자인 보니 살짝 다른 것 같아서 아예 `mypage` 경로를 새로 만들어서 옮겼습니다.
- qna, faq, notice 페이지도 만들어두셨길래 모두 `mypage` 폴더 안에 넣어서 `/mypage/~` 경로로 접근할 수 있습니다. 
- 디자인 시안과 일치하도록 css 수정도 살짝 했습니다.

2. 노션 링크로 이동하는 공지, 자주묻는질문 페이지는 임베드 처리 시도
- 공지(notice), 자주묻는질문(faq)는 노션 링크로 이동하길래 페이지 이탈을 방지하고자 iframe처럼 레이아웃 위에 노션 페이지를 띄우려고 시도했습니다.
- faq 페이지에 임시로 세팅 해봤는데, 생각보다 잘 되지 않아서 일단 보류해둔 상태입니다,,, ㅠ (현재 개발환경에서 작업을 하지 못하니 디버깅 확인이 어렵더라구용)
- 문의하기(qna) 페이지는 시안도 없고 링크도 없어서 "페이지 준비중 입니다."로 띄워놨습니다.